### PR TITLE
Add attacked player attribute to projectiles and add piercing feature

### DIFF
--- a/docs/attributes/projectiles.md
+++ b/docs/attributes/projectiles.md
@@ -17,4 +17,4 @@
 - `damage`: Damage done to players on collision
 - `speed`: Speed of the projectile
 - `size`: Size for the projectile model and collision math
-- `pierce`: Determines if the projectile is removed from game after colliding with a player
+- `remove_on_collision`: Determines if the projectile is removed from game after colliding with a player

--- a/docs/attributes/projectiles.md
+++ b/docs/attributes/projectiles.md
@@ -17,4 +17,4 @@
 - `damage`: Damage done to players on collision
 - `speed`: Speed of the projectile
 - `size`: Size for the projectile model and collision math
-- `player_collision`: Determines if the projectile is removed from game after colliding with a player
+- `pierce`: Determines if the projectile is removed from game after colliding with a player

--- a/docs/configuration/projectiles.md
+++ b/docs/configuration/projectiles.md
@@ -7,7 +7,7 @@ Configurable fields:
 - `base_damage`: Damage done by the projectile on collision
 - `base_speed`: Travel speed of the projectile
 - `base_size`: Size of the projectile for collision math
-- `pierce`: Determines if the projectile is removed from game after colliding with a player, default is `true`
+- `remove_on_collision`: Determines if the projectile is removed from game after colliding with a player, default is `true`
 - `on_hit_effects`: Effects given to target on collision
 - `duration_ms`: Defines how long in milliseconds the projectile can exist
 - `max_distance`: Defines the maximum distance the projectile can travel
@@ -25,7 +25,7 @@ Some example configurations
     "base_damage": 10,
     "base_speed": 123,
     "base_size": 50,
-    "pierce": false,
+    "remove_on_collision": true,
     "on_hit_effects": []
   },
   {

--- a/docs/configuration/projectiles.md
+++ b/docs/configuration/projectiles.md
@@ -7,7 +7,7 @@ Configurable fields:
 - `base_damage`: Damage done by the projectile on collision
 - `base_speed`: Travel speed of the projectile
 - `base_size`: Size of the projectile for collision math
-- `player_collision`: Determines if the projectile is removed from game after colliding with a player, default is `true`
+- `pierce`: Determines if the projectile is removed from game after colliding with a player, default is `true`
 - `on_hit_effects`: Effects given to target on collision
 - `duration_ms`: Defines how long in milliseconds the projectile can exist
 - `max_distance`: Defines the maximum distance the projectile can travel
@@ -25,7 +25,7 @@ Some example configurations
     "base_damage": 10,
     "base_speed": 123,
     "base_size": 50,
-    "player_collision": false,
+    "pierce": false,
     "on_hit_effects": []
   },
   {

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -331,13 +331,13 @@ fn apply_projectiles_collisions(
     projectiles.iter_mut().for_each(|projectile| {
         for player in players.values_mut() {
             if player.status == PlayerStatus::Alive
+                && !projectile.attacked_player_ids.contains(&player.id)
                 && map::hit_boxes_collide(
                     &projectile.position,
                     &player.position,
                     projectile.size,
                     player.size,
                 )
-                && !projectile.attacked_player_ids.contains(&player.id)
             {
                 if player.id == projectile.player_id {
                     continue;
@@ -347,9 +347,10 @@ fn apply_projectiles_collisions(
                 player.apply_effects(&projectile.on_hit_effects);
                 projectile.attacked_player_ids.push(player.id);
 
-                if !projectile.pierce {
+                if projectile.remove_on_collision {
                     projectile.active = false;
                 }
+                break;
             }
         }
     });

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -337,6 +337,7 @@ fn apply_projectiles_collisions(
                     projectile.size,
                     player.size,
                 )
+                && !projectile.attacked_player_ids.contains(&player.id)
             {
                 if player.id == projectile.player_id {
                     continue;
@@ -344,17 +345,11 @@ fn apply_projectiles_collisions(
 
                 player.decrease_health(projectile.damage);
                 player.apply_effects(&projectile.on_hit_effects);
+                projectile.attacked_player_ids.push(player.id);
 
-                projectile.active = false;
-                break;
-
-                // TODO: Uncomment (and fix) when projectile collision is a thing
-                //      move the `active` change and `break` to the else clause
-                // if projectile.collision == ENABLED {
-                //     continue;
-                // } else {
-                //     break;
-                // }
+                if !projectile.pierce {
+                    projectile.active = false;
+                }
             }
         }
     });

--- a/native/lambda_game_engine/src/projectile.rs
+++ b/native/lambda_game_engine/src/projectile.rs
@@ -12,6 +12,7 @@ pub struct ProjectileConfigFile {
     on_hit_effects: Vec<String>,
     duration_ms: u64,
     max_distance: u64,
+    pierce: bool,
 }
 
 #[derive(NifMap, Clone)]
@@ -23,6 +24,7 @@ pub struct ProjectileConfig {
     on_hit_effects: Vec<Effect>,
     duration_ms: u64,
     max_distance: u64,
+    pierce: bool,
 }
 
 #[derive(NifMap)]
@@ -39,6 +41,8 @@ pub struct Projectile {
     pub direction_angle: f32,
     pub player_id: u64,
     pub active: bool, // TODO: this should be `status` field with an enum value
+    pub pierce: bool,
+    pub attacked_player_ids: Vec<u64>,
 }
 
 impl ProjectileConfig {
@@ -63,6 +67,7 @@ impl ProjectileConfig {
                     on_hit_effects: effects,
                     duration_ms: config.duration_ms,
                     max_distance: config.max_distance,
+                    pierce: config.pierce,
                 }
             })
             .collect()
@@ -85,11 +90,13 @@ impl Projectile {
             on_hit_effects: config.on_hit_effects.clone(),
             duration_ms: config.duration_ms,
             max_distance: config.max_distance,
+            pierce: config.pierce,
             id,
             position,
             direction_angle,
             player_id,
             active: true,
+            attacked_player_ids: vec![],
         }
     }
 }

--- a/native/lambda_game_engine/src/projectile.rs
+++ b/native/lambda_game_engine/src/projectile.rs
@@ -12,7 +12,7 @@ pub struct ProjectileConfigFile {
     on_hit_effects: Vec<String>,
     duration_ms: u64,
     max_distance: u64,
-    pierce: bool,
+    remove_on_collision: bool,
 }
 
 #[derive(NifMap, Clone)]
@@ -24,7 +24,7 @@ pub struct ProjectileConfig {
     on_hit_effects: Vec<Effect>,
     duration_ms: u64,
     max_distance: u64,
-    pierce: bool,
+    remove_on_collision: bool,
 }
 
 #[derive(NifMap)]
@@ -41,7 +41,7 @@ pub struct Projectile {
     pub direction_angle: f32,
     pub player_id: u64,
     pub active: bool, // TODO: this should be `status` field with an enum value
-    pub pierce: bool,
+    pub remove_on_collision: bool,
     pub attacked_player_ids: Vec<u64>,
 }
 
@@ -67,7 +67,7 @@ impl ProjectileConfig {
                     on_hit_effects: effects,
                     duration_ms: config.duration_ms,
                     max_distance: config.max_distance,
-                    pierce: config.pierce,
+                    remove_on_collision: config.remove_on_collision,
                 }
             })
             .collect()
@@ -90,7 +90,7 @@ impl Projectile {
             on_hit_effects: config.on_hit_effects.clone(),
             duration_ms: config.duration_ms,
             max_distance: config.max_distance,
-            pierce: config.pierce,
+            remove_on_collision: config.remove_on_collision,
             id,
             position,
             direction_angle,

--- a/priv/config.json
+++ b/priv/config.json
@@ -49,7 +49,7 @@
           "value": "1.2"
         },
         {
-          "attribute": "pierce",
+          "attribute": "remove_on_collision",
           "modifier": "Override",
           "value": "false"
         }
@@ -99,7 +99,7 @@
       "base_damage": 20,
       "base_speed": 40,
       "base_size": 20,
-      "pierce": false,
+      "remove_on_collision": true,
       "on_hit_effects": [],
       "duration_ms": 999999,
       "max_distance": 999999
@@ -109,7 +109,7 @@
       "base_damage": 0,
       "base_speed": 60,
       "base_size": 10,
-      "pierce": true,
+      "remove_on_collision": false,
       "on_hit_effects": ["poison"],
       "duration_ms": 999999,
       "max_distance": 500

--- a/priv/config.json
+++ b/priv/config.json
@@ -49,7 +49,7 @@
           "value": "1.2"
         },
         {
-          "attribute": "player_collision",
+          "attribute": "pierce",
           "modifier": "Override",
           "value": "false"
         }
@@ -99,7 +99,7 @@
       "base_damage": 20,
       "base_speed": 40,
       "base_size": 20,
-      "player_collision": true,
+      "pierce": false,
       "on_hit_effects": [],
       "duration_ms": 999999,
       "max_distance": 999999
@@ -109,7 +109,7 @@
       "base_damage": 0,
       "base_speed": 60,
       "base_size": 10,
-      "player_collision": true,
+      "pierce": true,
       "on_hit_effects": ["poison"],
       "duration_ms": 999999,
       "max_distance": 500


### PR DESCRIPTION
- Projectiles now pierce.
- Projectiles store player ids who have attacked to prevent them from attacking again.