### PR TITLE
Player actions and skill duration

### DIFF
--- a/docs/attributes/players.md
+++ b/docs/attributes/players.md
@@ -11,6 +11,7 @@
 - `position`: Current position
 - `direction`: angle where the player is facing
 - `actions`: Actions taken by the player since the last world tick
+- `action_duration_ms`: Time in milliseconds remaining before a player can do another action, usually only skills add to this value (e.g. moving is free)
 
 ## Changeable attributes
 

--- a/docs/configuration/skills.md
+++ b/docs/configuration/skills.md
@@ -3,7 +3,8 @@
 ## Configuration
 
 - `name`: Unique name for the skill, this will be referenced by other configurations
-- `cooldown_ms`: Time that needs to elapse before the skill is usable again
+- `cooldown_ms`: Time that needs to elapse before the skill recharges
+- `usage_interval_ms`: Time between skill usage, skill is essentially disabled during this interval
 - `is_passive`: Marks the skill as a passive skill, this means it can't be triggered. Instead it will trigger on player spawn, so only `GiveEffect` makes sense for it
 - `mechanics`: Core mechanic of the skill (e.g hit, shoot, etc)
 

--- a/docs/configuration/skills.md
+++ b/docs/configuration/skills.md
@@ -4,7 +4,7 @@
 
 - `name`: Unique name for the skill, this will be referenced by other configurations
 - `cooldown_ms`: Time that needs to elapse before the skill recharges
-- `usage_interval_ms`: Time between skill usage, skill is essentially disabled during this interval
+- `execution_duration_ms`: Time in milliseconds it takes to perform the skill, player will be unable
 - `is_passive`: Marks the skill as a passive skill, this means it can't be triggered. Instead it will trigger on player spawn, so only `GiveEffect` makes sense for it
 - `mechanics`: Core mechanic of the skill (e.g hit, shoot, etc)
 

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -9,8 +9,8 @@ use crate::effect;
 use crate::effect::Effect;
 use crate::loot::Loot;
 use crate::map;
-use crate::player::Player;
 use crate::player::Action;
+use crate::player::Player;
 use crate::player::PlayerStatus;
 use crate::projectile::Projectile;
 use crate::skill::SkillMechanic;
@@ -307,9 +307,7 @@ fn distribute_angle(direction_angle: f32, cone_angle: &u64, count: &u64) -> Vec<
 }
 
 fn update_player_actions(players: &mut HashMap<u64, Player>, elapsed_time_ms: u64) {
-    players
-    .values_mut()
-    .for_each(|player| {
+    players.values_mut().for_each(|player| {
         player.update_actions();
         player.action_duration_ms = player.action_duration_ms.saturating_sub(elapsed_time_ms);
     })

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -142,8 +142,13 @@ impl GameState {
             .partition(|player| player.id == player_id);
 
         if let Some(player) = player_in_list.get_mut(0) {
+            // Check if player is still performing an action
+            if player.action_duration_ms > 0 {
+                return;
+            }
+
             if let Some(skill) = player.character.clone().skills.get(&skill_key) {
-                player.add_action(Action::UsingSkill(skill_key));
+                player.add_action(Action::UsingSkill(skill_key), skill.execution_duration_ms);
 
                 for mechanic in skill.mechanics.iter() {
                     match mechanic {
@@ -231,7 +236,7 @@ impl GameState {
     }
 
     pub fn tick(&mut self, time_diff: u64) {
-        update_player_actions(&mut self.players);
+        update_player_actions(&mut self.players, time_diff);
         move_projectiles(&mut self.projectiles, time_diff, &self.config);
         apply_projectiles_collisions(&mut self.projectiles, &mut self.players);
         run_effects(&mut self.players, time_diff);
@@ -301,10 +306,13 @@ fn distribute_angle(direction_angle: f32, cone_angle: &u64, count: &u64) -> Vec<
     angles
 }
 
-fn update_player_actions(players: &mut HashMap<u64, Player>) {
+fn update_player_actions(players: &mut HashMap<u64, Player>, elapsed_time_ms: u64) {
     players
     .values_mut()
-    .for_each(|player| player.update_actions())
+    .for_each(|player| {
+        player.update_actions();
+        player.action_duration_ms = player.action_duration_ms.saturating_sub(elapsed_time_ms);
+    })
 }
 
 fn move_projectiles(projectiles: &mut Vec<Projectile>, time_diff: u64, config: &Config) {

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -10,6 +10,7 @@ use crate::effect::Effect;
 use crate::loot::Loot;
 use crate::map;
 use crate::player::Player;
+use crate::player::Action;
 use crate::player::PlayerStatus;
 use crate::projectile::Projectile;
 use crate::skill::SkillMechanic;
@@ -142,6 +143,8 @@ impl GameState {
 
         if let Some(player) = player_in_list.get_mut(0) {
             if let Some(skill) = player.character.clone().skills.get(&skill_key) {
+                player.add_action(Action::UsingSkill(skill_key));
+
                 for mechanic in skill.mechanics.iter() {
                     match mechanic {
                         SkillMechanic::SimpleShoot {
@@ -228,6 +231,7 @@ impl GameState {
     }
 
     pub fn tick(&mut self, time_diff: u64) {
+        update_player_actions(&mut self.players);
         move_projectiles(&mut self.projectiles, time_diff, &self.config);
         apply_projectiles_collisions(&mut self.projectiles, &mut self.players);
         run_effects(&mut self.players, time_diff);
@@ -295,6 +299,12 @@ fn distribute_angle(direction_angle: f32, cone_angle: &u64, count: &u64) -> Vec<
     }
 
     angles
+}
+
+fn update_player_actions(players: &mut HashMap<u64, Player>) {
+    players
+    .values_mut()
+    .for_each(|player| player.update_actions())
 }
 
 fn move_projectiles(projectiles: &mut Vec<Projectile>, time_diff: u64, config: &Config) {

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -38,11 +38,8 @@ pub enum PlayerStatus {
 #[derive(NifTaggedEnum, Clone)]
 pub enum PlayerAction {
     Nothing,
-    Attacking,
-    Attackingaoe,
     Moving,
-    StartingSkill(String),
-    ExecutingSkill(String),
+    UsingSkill(String),
 }
 
 impl Player {

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -72,7 +72,7 @@ impl Player {
             return;
         }
 
-        self.add_action(Action::Moving);
+        self.add_action(Action::Moving, 0);
         self.direction = angle_degrees;
         self.position = map::next_position(
             &self.position,
@@ -83,8 +83,9 @@ impl Player {
         );
     }
 
-    pub fn add_action(&mut self, action: Action) {
+    pub fn add_action(&mut self, action: Action, duration_ms: u64) {
         self.next_actions.push(action);
+        self.action_duration_ms += duration_ms;
     }
 
     pub fn update_actions(&mut self) {

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -20,13 +20,15 @@ pub struct Player {
     pub death_count: u64,
     pub position: Position,
     pub direction: f32,
-    pub actions: Vec<PlayerAction>,
+    pub actions: Vec<Action>,
     pub health: u64,
     pub cooldowns: HashMap<String, u64>,
     pub effects: Vec<Effect>,
     pub size: u64,
     pub damage: u64,
     pub speed: u64,
+    pub action_duration_ms: u64,
+    next_actions: Vec<Action>,
 }
 
 #[derive(NifTaggedEnum, Clone, PartialEq)]
@@ -36,7 +38,7 @@ pub enum PlayerStatus {
 }
 
 #[derive(NifTaggedEnum, Clone)]
-pub enum PlayerAction {
+pub enum Action {
     Nothing,
     Moving,
     UsingSkill(String),
@@ -59,6 +61,8 @@ impl Player {
             speed: character_config.base_speed,
             size: character_config.base_size,
             character: character_config,
+            action_duration_ms: 0,
+            next_actions: Vec::new(),
         }
     }
 
@@ -68,6 +72,7 @@ impl Player {
             return;
         }
 
+        self.add_action(Action::Moving);
         self.direction = angle_degrees;
         self.position = map::next_position(
             &self.position,
@@ -76,6 +81,15 @@ impl Player {
             config.game.width as f32,
             config.game.height as f32,
         );
+    }
+
+    pub fn add_action(&mut self, action: Action) {
+        self.next_actions.push(action);
+    }
+
+    pub fn update_actions(&mut self) {
+        self.actions = self.next_actions.clone();
+        self.next_actions.clear();
     }
 
     pub fn apply_effects(&mut self, effects: &[Effect]) {

--- a/native/lambda_game_engine/src/skill.rs
+++ b/native/lambda_game_engine/src/skill.rs
@@ -7,7 +7,7 @@ use crate::{effect::Effect, projectile::ProjectileConfig};
 pub struct SkillConfigFile {
     name: String,
     cooldown_ms: u64,
-    usage_interval_ms: u64,
+    execution_duration_ms: u64,
     is_passive: bool,
     mechanics: Vec<SkillMechanicConfigFile>,
 }
@@ -16,7 +16,7 @@ pub struct SkillConfigFile {
 pub struct SkillConfig {
     pub name: String,
     pub cooldown_ms: u64,
-    pub usage_interval_ms: u64,
+    pub execution_duration_ms: u64,
     pub is_passive: bool,
     pub mechanics: Vec<SkillMechanic>,
 }
@@ -82,7 +82,7 @@ impl SkillConfig {
                 SkillConfig {
                     name: config.name.clone(),
                     cooldown_ms: config.cooldown_ms,
-                    usage_interval_ms: config.usage_interval_ms,
+                    execution_duration_ms: config.execution_duration_ms,
                     is_passive: config.is_passive,
                     mechanics,
                 }

--- a/native/lambda_game_engine/src/skill.rs
+++ b/native/lambda_game_engine/src/skill.rs
@@ -7,6 +7,7 @@ use crate::{effect::Effect, projectile::ProjectileConfig};
 pub struct SkillConfigFile {
     name: String,
     cooldown_ms: u64,
+    usage_interval_ms: u64,
     is_passive: bool,
     mechanics: Vec<SkillMechanicConfigFile>,
 }
@@ -15,6 +16,7 @@ pub struct SkillConfigFile {
 pub struct SkillConfig {
     pub name: String,
     pub cooldown_ms: u64,
+    pub usage_interval_ms: u64,
     pub is_passive: bool,
     pub mechanics: Vec<SkillMechanic>,
 }
@@ -80,6 +82,7 @@ impl SkillConfig {
                 SkillConfig {
                     name: config.name.clone(),
                     cooldown_ms: config.cooldown_ms,
+                    usage_interval_ms: config.usage_interval_ms,
                     is_passive: config.is_passive,
                     mechanics,
                 }

--- a/priv/config.json
+++ b/priv/config.json
@@ -119,7 +119,7 @@
     {
       "name": "slingshot",
       "cooldown_ms": 800,
-      "usage_interval_ms": 250,
+      "execution_duration_ms": 250,
       "is_passive": false,
       "mechanics": [
         {
@@ -134,7 +134,7 @@
     {
       "name": "poison_dart",
       "cooldown_ms": 800,
-      "usage_interval_ms": 150,
+      "execution_duration_ms": 150,
       "is_passive": false,
       "mechanics": [
         {
@@ -147,7 +147,7 @@
     {
       "name": "hit",
       "cooldown_ms": 1500,
-      "usage_interval_ms": 500,
+      "execution_duration_ms": 500,
       "is_passive": false,
       "mechanics": [
         {
@@ -163,7 +163,7 @@
     {
       "name": "circle_hit",
       "cooldown_ms": 1500,
-      "usage_interval_ms": 800,
+      "execution_duration_ms": 800,
       "is_passive": false,
       "mechanics": [
         {

--- a/priv/config.json
+++ b/priv/config.json
@@ -119,6 +119,7 @@
     {
       "name": "slingshot",
       "cooldown_ms": 800,
+      "usage_interval_ms": 250,
       "is_passive": false,
       "mechanics": [
         {
@@ -133,6 +134,7 @@
     {
       "name": "poison_dart",
       "cooldown_ms": 800,
+      "usage_interval_ms": 150,
       "is_passive": false,
       "mechanics": [
         {
@@ -145,6 +147,7 @@
     {
       "name": "hit",
       "cooldown_ms": 1500,
+      "usage_interval_ms": 500,
       "is_passive": false,
       "mechanics": [
         {
@@ -160,6 +163,7 @@
     {
       "name": "circle_hit",
       "cooldown_ms": 1500,
+      "usage_interval_ms": 800,
       "is_passive": false,
       "mechanics": [
         {


### PR DESCRIPTION
- Adds concept of `Action` to a player, keeping track of each action performed between game ticks
- Add duration to actions and enforce a "no action" cooldown between skill invocations, movement remains free (no duration to execute)