### PR TITLE
Zone shrinking

### DIFF
--- a/docs/configuration/effects.md
+++ b/docs/configuration/effects.md
@@ -7,6 +7,7 @@ Effects are mostly buffs and debuffs players can have. They will given by skills
 Configurable fields:
 - `name`: unique name for the effect, this will be referenced by other configurations
 - `effect_time_type`: This determines how the effect is applied, see below ["Effect time type"](#effect-time-type)
+- `is_reversable`: Defines if the effect can be reversed when removed from the player (e.g. if it gives 10% more speed it will be removed from the player on removal), see more in ["Adding and removing effects"](#adding-and-removing-effects)
 - `player_attributes`: Attributes changes that will be applied over the player having this effect
 - `projectile_attributes`: Attributes changes that will be applied over the projectiles of the player having this effect
 
@@ -71,6 +72,7 @@ Examples of the JSON defining effects
 [
   {
     "name": "gain_health_10_3s"
+    "is_reversable": false,
     "effect_time_type": {
       "type": "Periodic",
       "instant_application": false
@@ -107,7 +109,7 @@ Examples of the JSON defining effects
 ]
 ```
 
-### Adding an removing effects
+### Adding and removing effects
 
 Some effects result in an increase in a player's attributes. When the effect's duration expires, we need to revert the changes made to the attribute. To address this, we've implemented a revert_attribute function that undoes the effect's modifications.
 

--- a/docs/configuration/game.md
+++ b/docs/configuration/game.md
@@ -6,17 +6,23 @@ This is the meta configuration for the game, not for a particular thing in the g
 
 - `width`: Defines the width of the playing area
 - `height`: Defines the length of the playing area
-- `map_modification`: If present, contains the information for when the map modification mechanic is triggered, see below [Map modification](#map-modification)
+- `zone_starting_radius`: Radius of the playable zone. The zone is an area in the map where effects are applied to players not in it
+- `zone_modifications`: This is attribute is a list of modifications to perform to the playable zone in the map. For the specifics see below ["Zone modification"](#zone-modification)
 - `loot_interval_ms`: If present, interval in milliseconds for spawning loot crates
 
-### Map modification
+### Zone modification
 
-- `modification`: Defines how to modify the playable area radius, similar to attributes changes it has a `modifier` and `value` fields
-- `starting_radius`: Starting radius for the playable area
-- `minimum_radius`: Mininum radius for the playable area, how small can the playable zone get
-- `max_radius`: Max radius for the playable area, how big can the playable zone get
-- `outside_radius_effects`: Effects given when a player is outside the playable area
-- `inside_radius_effects`: Effects given when a player is inside the playable area
+As mentioned this attribute is composed of a list of "modifications". This modifications are processed in order and once the `duration_ms` of the current one is reached the engine will start move on to the next one and apply changes based on those rules. If you don't wish to have any modifications you can set an empty list
+
+This "modifications" are compose of the following fields
+
+- `duration_ms`: Duration the modification should be applied for
+- `modification`: Defines how to modify the playable zone radius, similar to attributes changes it has a `modifier` and `value` fields
+- `recenter_on_first_modification`: Determines if the center of the zone should change (randomly) when we first apply this modification. The new center will be inside the zone and limiting to a place where `min_radius` still fits
+- `interval_ms`: Every X milliseconds the modification is applied
+- `min_radius`: Mininum radius for the playable zone, how small can the playable zone get
+- `max_radius`: Max radius for the playable zone, how big can the playable zone get
+- `outside_radius_effects`: Effects given when a player is outside the playable zone
 
 ### Example
 
@@ -24,17 +30,22 @@ This is the meta configuration for the game, not for a particular thing in the g
 {
   "width": 10000,
   "height": 10000,
-  "map_modification": {
-    "modification": {
-      "modifier": "Multiplicative",
-      "value": 0.9,
-    },
-    "starting_radius": 10000,
-    "minimum_radius": 1800,
-    "max_radius": 10000,
-    "outside_radius_effects": [],
-    "inside_radius_effects": ["damage_outside_area"]
-  }
+  "zone_starting_radius": 10000,
+  "zone_modification": [
+    {
+      "duration_ms": 1000,
+      "modification": {
+        "modifier": "Multiplicative",
+        "value": 0.9,
+      },
+      "recenter_on_first_modification": true,
+      "interval_ms": 500,
+      "trigger_count": 5000,
+      "min_radius": 1800,
+      "max_radius": 10000,
+      "outside_radius_effects": [damage_outside_area],
+    }
+  ]
   "loot_interval_ms": 7000
 }
 ```

--- a/docs/configuration/game.md
+++ b/docs/configuration/game.md
@@ -12,13 +12,12 @@ This is the meta configuration for the game, not for a particular thing in the g
 
 ### Zone modification
 
-As mentioned this attribute is composed of a list of "modifications". This modifications are processed in order and once the `duration_ms` of the current one is reached the engine will start move on to the next one and apply changes based on those rules. If you don't wish to have any modifications you can set an empty list
+As mentioned this attribute is composed of a list of "modifications". This modifications are processed in order and once the `duration_ms` of the current one is reached the engine will move on to the next one and apply changes based on those rules. If you don't wish to have any modifications you can set an empty list
 
 This "modifications" are compose of the following fields
 
 - `duration_ms`: Duration the modification should be applied for
 - `modification`: Defines how to modify the playable zone radius, similar to attributes changes it has a `modifier` and `value` fields
-- `recenter_on_first_modification`: Determines if the center of the zone should change (randomly) when we first apply this modification. The new center will be inside the zone and limiting to a place where `min_radius` still fits
 - `interval_ms`: Every X milliseconds the modification is applied
 - `min_radius`: Mininum radius for the playable zone, how small can the playable zone get
 - `max_radius`: Max radius for the playable zone, how big can the playable zone get
@@ -38,7 +37,6 @@ This "modifications" are compose of the following fields
         "modifier": "Multiplicative",
         "value": 0.9,
       },
-      "recenter_on_first_modification": true,
       "interval_ms": 500,
       "trigger_count": 5000,
       "min_radius": 1800,

--- a/native/lambda_game_engine/src/effect.rs
+++ b/native/lambda_game_engine/src/effect.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 #[derive(Deserialize, NifMap, Clone)]
 pub struct Effect {
     pub name: String,
+    pub is_reversable: bool,
     pub effect_time_type: TimeType,
     pub player_attributes: Vec<AttributeChange>,
     pub projectile_attributes: Vec<AttributeChange>,

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -523,7 +523,10 @@ fn apply_zone_effects(players: &mut HashMap<u64, Player>, zone: &Zone) {
         });
 
         outside_players.into_iter().for_each(|player| {
-            player.apply_effects(&current_modification.outside_radius_effects, EntityOwner::Zone);
+            player.apply_effects(
+                &current_modification.outside_radius_effects,
+                EntityOwner::Zone,
+            );
         });
     }
 }

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -436,5 +436,26 @@ fn modify_zone(zone: &mut Zone, time_diff: u64) {
 }
 
 fn apply_zone_effects(players: &mut HashMap<u64, Player>, zone: &Zone) {
-    todo!()
+    if let Some(current_modification) = &zone.current_modification {
+        let (inside_players, outside_players): (Vec<_>, Vec<_>) = players
+            .values_mut()
+            // We set size of player as 0 so a player has to be half way inside the zone to be considered inside
+            // otherwise if just a border of the player where inside it would be considered inside which seems wrong
+            .partition(|player| map::hit_boxes_collide(&zone.center, &player.position, zone.radius, 0));
+
+        inside_players
+            .into_iter()
+            .for_each(|player| {
+                for effect in current_modification.outside_radius_effects.iter() {
+                    player.remove_effect(&effect.name)
+                }
+            });
+
+        outside_players
+            .into_iter()
+            .for_each(|player| {
+                player.apply_effects(&current_modification.outside_radius_effects);
+            });
+    }
+
 }

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -133,15 +133,23 @@ impl Player {
     }
 
     pub fn remove_effect(&mut self, effect_key: &str) {
-        if let Some(pos) = self.effects.iter().position(|effect| effect.name == effect_key) {
+        if let Some(pos) = self
+            .effects
+            .iter()
+            .position(|effect| effect.name == effect_key)
+        {
             let effect = self.effects.remove(pos);
 
             if effect.is_reversable {
                 effect.player_attributes.iter().for_each(|change| {
                     match change.attribute.as_str() {
-                        "health" => revert_attribute(&mut self.health, &change.modifier, &change.value),
+                        "health" => {
+                            revert_attribute(&mut self.health, &change.modifier, &change.value)
+                        }
                         "size" => revert_attribute(&mut self.size, &change.modifier, &change.value),
-                        "speed" => revert_attribute(&mut self.speed, &change.modifier, &change.value),
+                        "speed" => {
+                            revert_attribute(&mut self.speed, &change.modifier, &change.value)
+                        }
                         _ => todo!(),
                     };
                 });
@@ -173,7 +181,6 @@ impl Player {
             })
             .cloned()
             .collect();
-
 
         for effect in effects_to_remove.iter() {
             if !effect.is_reversable {

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -136,7 +136,7 @@ impl Player {
         if let Some(pos) = self.effects.iter().position(|effect| effect.name == effect_key) {
             let effect = self.effects.remove(pos);
 
-            // if effect.is_reversable {
+            if effect.is_reversable {
                 effect.player_attributes.iter().for_each(|change| {
                     match change.attribute.as_str() {
                         "health" => revert_attribute(&mut self.health, &change.modifier, &change.value),
@@ -145,7 +145,7 @@ impl Player {
                         _ => todo!(),
                     };
                 });
-            // }
+            }
         }
     }
 
@@ -174,7 +174,12 @@ impl Player {
             .cloned()
             .collect();
 
+
         for effect in effects_to_remove.iter() {
+            if !effect.is_reversable {
+                continue;
+            }
+
             effect.player_attributes.iter().for_each(|change| {
                 match change.attribute.as_str() {
                     "health" => revert_attribute(&mut self.health, &change.modifier, &change.value),

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -132,6 +132,23 @@ impl Player {
         };
     }
 
+    pub fn remove_effect(&mut self, effect_key: &str) {
+        if let Some(pos) = self.effects.iter().position(|effect| effect.name == effect_key) {
+            let effect = self.effects.remove(pos);
+
+            // if effect.is_reversable {
+                effect.player_attributes.iter().for_each(|change| {
+                    match change.attribute.as_str() {
+                        "health" => revert_attribute(&mut self.health, &change.modifier, &change.value),
+                        "size" => revert_attribute(&mut self.size, &change.modifier, &change.value),
+                        "speed" => revert_attribute(&mut self.speed, &change.modifier, &change.value),
+                        _ => todo!(),
+                    };
+                });
+            // }
+        }
+    }
+
     pub fn decrease_health(&mut self, amount: u64) {
         self.health = self.health.saturating_sub(amount);
 

--- a/priv/config.json
+++ b/priv/config.json
@@ -57,7 +57,13 @@
     },
     {
       "name": "damage_outside_area",
-      "effect_time_type": "Instant",
+      "effect_time_type": {
+        "Periodic": {
+          "instant_applicaiton": false,
+          "interval_ms": 1000,
+          "trigger_count": 999999
+        }
+      },
       "player_attributes": [
         {
           "attribute": "health",

--- a/priv/config.json
+++ b/priv/config.json
@@ -212,7 +212,6 @@
           "modifier": "Multiplicative",
           "value": 0.9
         },
-        "recenter_on_first_modification": true,
         "interval_ms": 500,
         "min_radius": 6000,
         "max_radius": 10000,
@@ -224,7 +223,6 @@
           "modifier": "Multiplicative",
           "value": 0.8
         },
-        "recenter_on_first_modification": true,
         "interval_ms": 500,
         "min_radius": 3000,
         "max_radius": 10000,
@@ -236,7 +234,6 @@
           "modifier": "Multiplicative",
           "value": 0.7
         },
-        "recenter_on_first_modification": true,
         "interval_ms": 500,
         "min_radius": 1000,
         "max_radius": 10000,

--- a/priv/config.json
+++ b/priv/config.json
@@ -2,6 +2,7 @@
   "effects": [
     {
       "name": "test_effect",
+      "is_reversable": true,
       "effect_time_type": {
         "Duration": {
           "duration_ms": 6000
@@ -18,6 +19,7 @@
     },
     {
       "name": "heal_30",
+      "is_reversable": false,
       "effect_time_type": "Instant",
       "player_attributes": [
         {
@@ -30,6 +32,7 @@
     },
     {
       "name": "h4ck_dos",
+      "is_reversable": true,
       "effect_time_type": {
         "Duration": {
           "duration_ms": 6000
@@ -57,6 +60,7 @@
     },
     {
       "name": "damage_outside_area",
+      "is_reversable": false,
       "effect_time_type": {
         "Periodic": {
           "instant_applicaiton": false,
@@ -75,6 +79,7 @@
     },
     {
       "name": "poison",
+      "is_reversable": false,
       "effect_time_type": {
         "Periodic": {
           "instant_applicaiton": false,

--- a/priv/config.json
+++ b/priv/config.json
@@ -204,17 +204,45 @@
   "game": {
     "width": 10000,
     "height": 10000,
-    "map_modification": {
-      "modification": {
-        "modifier": "Multiplicative",
-        "value": 0.9
+    "zone_starting_radius": 10000,
+    "zone_modifications": [
+      {
+        "duration_ms": 10000,
+        "modification": {
+          "modifier": "Multiplicative",
+          "value": 0.9
+        },
+        "recenter_on_first_modification": true,
+        "interval_ms": 500,
+        "min_radius": 6000,
+        "max_radius": 10000,
+        "outside_radius_effects": ["damage_outside_area"]
       },
-      "starting_radius": 10000,
-      "minimum_radius": 1800,
-      "max_radius": 10000,
-      "outside_radius_effects": [],
-      "inside_radius_effects": ["damage_outside_area"]
-    },
+      {
+        "duration_ms": 8000,
+        "modification": {
+          "modifier": "Multiplicative",
+          "value": 0.8
+        },
+        "recenter_on_first_modification": true,
+        "interval_ms": 500,
+        "min_radius": 3000,
+        "max_radius": 10000,
+        "outside_radius_effects": ["damage_outside_area"]
+      },
+      {
+        "duration_ms": 10000,
+        "modification": {
+          "modifier": "Multiplicative",
+          "value": 0.7
+        },
+        "recenter_on_first_modification": true,
+        "interval_ms": 500,
+        "min_radius": 1000,
+        "max_radius": 10000,
+        "outside_radius_effects": ["damage_outside_area"]
+      }
+    ],
     "loot_interval_ms": 7000
   }
 }

--- a/test/lambda_game_engine_test.exs
+++ b/test/lambda_game_engine_test.exs
@@ -23,6 +23,21 @@ defmodule LambdaGameEngineTest do
     assert is_map(LambdaGameEngine.parse_config(data))
   end
 
+  test "parsed zone config retains modifications order" do
+    {:ok, data} =
+      Application.app_dir(:lambda_game_engine, "priv/config.json")
+      |> File.read()
+
+    config = LambdaGameEngine.parse_config(data)
+
+    ## This asserts are based on how config.json is written so any changes on the
+    ## modification stages will likely require a change here
+    [zone_modification1, zone_modification2, zone_modification3] = config.game.zone_modifications
+    assert zone_modification1.min_radius == 6000
+    assert zone_modification2.min_radius == 3000
+    assert zone_modification3.min_radius == 1000
+  end
+
   test "can add a player" do
     {:ok, data} =
       Application.app_dir(:lambda_game_engine, "priv/config.json")


### PR DESCRIPTION
- New configuration to define zone modification
- Game tick runs zone modifications
- Game tick apply zone effects to players
- Adds `is_reversable` to `Effect` to enable differentiating between effects that should be reversed and ones that should not