### PR TITLE
Set player as dead when killed by the zone

### DIFF
--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -530,6 +530,7 @@ fn apply_zone_effects(
         });
 
         outside_players.into_iter().for_each(|player| {
+            // If the player is alive in this tick, but dies as an effect of the zone, we push it to the killfeed.
             if player.status == PlayerStatus::Alive {
                 player.apply_effects_if_not_present(
                     &current_modification.outside_radius_effects,

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -304,7 +304,7 @@ impl GameState {
         remove_expired_effects(&mut self.players);
         run_effects(&mut self.players, time_diff, &mut self.next_killfeed);
         modify_zone(&mut self.zone, time_diff);
-        apply_zone_effects(&mut self.players, &self.zone);
+        apply_zone_effects(&mut self.players, &self.zone, &mut self.next_killfeed);
 
         self.killfeed = self.next_killfeed.clone();
         self.next_killfeed.clear();
@@ -508,7 +508,12 @@ fn modify_zone(zone: &mut Zone, time_diff: u64) {
     }
 }
 
-fn apply_zone_effects(players: &mut HashMap<u64, Player>, zone: &Zone) {
+fn apply_zone_effects(
+    players: &mut HashMap<u64, Player>,
+    zone: &Zone,
+    next_killfeed: &mut Vec<KillEvent>,
+) {
+    // next_killfeed
     if let Some(current_modification) = &zone.current_modification {
         let (inside_players, outside_players): (Vec<_>, Vec<_>) = players
             .values_mut()
@@ -525,10 +530,18 @@ fn apply_zone_effects(players: &mut HashMap<u64, Player>, zone: &Zone) {
         });
 
         outside_players.into_iter().for_each(|player| {
-            player.apply_effects_if_not_present(
-                &current_modification.outside_radius_effects,
-                EntityOwner::Zone,
-            );
+            if player.status == PlayerStatus::Alive {
+                player.apply_effects_if_not_present(
+                    &current_modification.outside_radius_effects,
+                    EntityOwner::Zone,
+                );
+                if player.status == PlayerStatus::Death {
+                    next_killfeed.push(KillEvent {
+                        kill_by: EntityOwner::Zone,
+                        killed: player.id,
+                    });
+                }
+            }
         });
     }
 }

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -260,6 +260,7 @@ impl Player {
                                         &change.modifier,
                                         &change.value,
                                     );
+                                    // TODO: refactor the use of references in order to use the update_status() remove the following duplicated code
                                     if self.health == 0 {
                                         self.status = PlayerStatus::Death;
                                     }

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -260,7 +260,7 @@ impl Player {
                                         &change.modifier,
                                         &change.value,
                                     );
-                                    if self.health <= 0 {
+                                    if self.health == 0 {
                                         self.status = PlayerStatus::Death;
                                     }
                                 }
@@ -283,7 +283,7 @@ impl Player {
 
 fn update_status(player: &mut Player) {
     println!("Health: {}", player.health);
-    if player.health <= 0 {
+    if player.health == 0 {
         player.status = PlayerStatus::Death;
     }
 }

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -282,7 +282,6 @@ impl Player {
 }
 
 fn update_status(player: &mut Player) {
-    println!("Health: {}", player.health);
     if player.health == 0 {
         player.status = PlayerStatus::Death;
     }

--- a/native/lambda_game_engine/src/player.rs
+++ b/native/lambda_game_engine/src/player.rs
@@ -140,11 +140,14 @@ impl Player {
                             "size" => {
                                 modify_attribute(&mut player.size, &change.modifier, &change.value)
                             }
-                            "health" => modify_attribute(
-                                &mut player.health,
-                                &change.modifier,
-                                &change.value,
-                            ),
+                            "health" => {
+                                modify_attribute(
+                                    &mut player.health,
+                                    &change.modifier,
+                                    &change.value,
+                                );
+                                update_status(player);
+                            }
                             _ => todo!(),
                         };
                         player
@@ -180,10 +183,7 @@ impl Player {
 
     pub fn decrease_health(&mut self, amount: u64) {
         self.health = self.health.saturating_sub(amount);
-
-        if self.health == 0 {
-            self.status = PlayerStatus::Death;
-        }
+        update_status(self);
     }
 
     pub fn remove_expired_effects(&mut self) {
@@ -251,11 +251,17 @@ impl Player {
 
                         effect.player_attributes.iter().for_each(|change| {
                             match change.attribute.as_str() {
-                                "health" => modify_attribute(
-                                    &mut self.health,
-                                    &change.modifier,
-                                    &change.value,
-                                ),
+                                "health" => {
+                                    modify_attribute(
+                                        &mut self.health,
+                                        &change.modifier,
+                                        &change.value,
+                                    );
+                                    if self.health <= 0 {
+                                        self.status = PlayerStatus::Death;
+                                    }
+                                }
+
                                 _ => todo!(),
                             };
                         });
@@ -267,7 +273,15 @@ impl Player {
                 _ => todo!(),
             }
         }
+
         None
+    }
+}
+
+fn update_status(player: &mut Player) {
+    println!("Health: {}", player.health);
+    if player.health <= 0 {
+        player.status = PlayerStatus::Death;
     }
 }
 


### PR DESCRIPTION
We weren't changing the status from Alive to Dead when a player died because of the zone damage.