### PR TITLE
Auto aim attacks

### DIFF
--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -544,3 +544,29 @@ fn apply_zone_effects(players: &mut HashMap<u64, Player>, zone: &Zone) {
         });
     }
 }
+
+fn nearest_player(
+    players: &Vec<&mut Player>,
+    position: &Position,
+) -> Option<(u64, Position)> {
+    let mut nearest_player = None;
+    let mut nearest_distance = 3000.0;
+
+    for player in players {
+        if matches!(player.status, PlayerStatus::Alive) {
+            let distance = distance_to_center(player, position);
+            if distance < nearest_distance
+            {
+                nearest_player = Some((player.id, player.position));
+                nearest_distance = distance;
+            }
+        }
+    }
+    nearest_player
+}
+
+fn distance_to_center(player: &Player, center: &Position) -> f32 {
+    let distance_squared =
+        (player.position.x - center.x).pow(2) + (player.position.y - center.y).pow(2);
+    (distance_squared as f32).sqrt()
+}

--- a/native/lambda_game_engine/src/game.rs
+++ b/native/lambda_game_engine/src/game.rs
@@ -191,10 +191,28 @@ impl GameState {
             if let Some(skill) = player.character.clone().skills.get(&skill_key) {
                 player.add_action(Action::UsingSkill(skill_key), skill.execution_duration_ms);
 
-                let direction_angle = skill_params
-                    .get("direction_angle")
-                    .map(|angle_str| angle_str.parse::<f32>().unwrap())
+                let auto_aim = skill_params
+                    .get("auto_aim")
+                    .map(|auto_aim_str| auto_aim_str.parse::<bool>().unwrap())
                     .unwrap();
+
+                let direction_angle = if auto_aim {
+                    let nearest_player: Option<(u64, Position)> = nearest_player(
+                        &other_players,
+                        &player.position
+                    );
+
+                    if let Some((_target_player_id, target_player_position)) = nearest_player {
+                        map::angle_between_positions(&player.position, &target_player_position)
+                    } else {
+                        player.direction
+                    }
+                } else {
+                    skill_params
+                        .get("direction_angle")
+                        .map(|angle_str| angle_str.parse::<f32>().unwrap())
+                        .unwrap()
+                };
 
                 player.direction = direction_angle;
 

--- a/native/lambda_game_engine/src/map.rs
+++ b/native/lambda_game_engine/src/map.rs
@@ -5,7 +5,7 @@ use rustler::NifMap;
 
 use crate::player::Player;
 
-#[derive(NifMap, Clone)]
+#[derive(NifMap, Clone, Copy)]
 pub struct Position {
     pub x: i64,
     pub y: i64,
@@ -105,4 +105,11 @@ pub fn random_position(width: u64, height: u64) -> Position {
         x: rng.gen_range(-bound_x..bound_x),
         y: rng.gen_range(-bound_y..bound_y),
     }
+}
+
+pub fn angle_between_positions(center: &Position, target: &Position) -> f32 {
+    let x_diff = (target.x - center.x) as f32;
+    let y_diff = (target.y - center.y) as f32;
+    let angle = y_diff.atan2(x_diff) * (180.0 / PI);
+    (angle + 360.0) % 360.0
 }


### PR DESCRIPTION
Closes #596 

## Motivation

We need to auto-attack with all skills if the attack button is tapped.

## Summary of changes

- Added a boolean that helps us to know if you are targeting or auto-attacking.
- Look for the nearest players to attack, and attack in that direction.

## How has this been tested?

Use some bots, and you will auto-attack in the direction of your opponents.